### PR TITLE
feat(compare-appian): Add unit tests for compare-appian handlers

### DIFF
--- a/src/services/compare-appian/handlers/compare.ts
+++ b/src/services/compare-appian/handlers/compare.ts
@@ -13,7 +13,10 @@ exports.handler = async function (
     if (has(data, ["seatoolRecord", "STATE_PLAN", "SUBMISSION_DATE"])) {
       data.seatoolSubmissionDate =
         data.seatoolRecord.STATE_PLAN.SUBMISSION_DATE;
+    } else {
+      throw "Required SEA Tool data missing";
     }
+
     if (
       data.appianSubmittedDate &&
       data.seatoolSubmissionDate &&

--- a/src/services/compare-appian/handlers/tests/compare.test.ts
+++ b/src/services/compare-appian/handlers/tests/compare.test.ts
@@ -3,7 +3,6 @@ import * as compare from "../compare";
 import * as libs from "../../../../libs";
 
 const appianCompare = compare as { handler: Function };
-
 const callback = vi.fn();
 
 const event = {
@@ -20,7 +19,8 @@ const event = {
 
 describe("compare", () => {
   beforeEach(() => {
-    vi.spyOn(console, "log");
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(libs, "trackError");
   });
 
@@ -60,6 +60,10 @@ describe("compare", () => {
 
       await appianCompare.handler(malformedEvent, null, callback);
       expect(libs.trackError).toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        "ERROR:",
+        JSON.stringify("Required SEA Tool data missing", null, 2)
+      );
     });
 
     it("should return data with match set to false if data doesn't include appianSubmittedDate", async () => {

--- a/src/services/compare-appian/handlers/tests/compare.test.ts
+++ b/src/services/compare-appian/handlers/tests/compare.test.ts
@@ -66,7 +66,7 @@ describe("compare", () => {
       );
     });
 
-    it("should return data with match set to false if data doesn't include appianSubmittedDate", async () => {
+    it("should send data to callback with match set to false if data doesn't include appianSubmittedDate", async () => {
       const noAppianDate = {
         Payload: {
           seatoolRecord: {
@@ -83,7 +83,7 @@ describe("compare", () => {
       expect(callback.mock.calls[0][1]["match"]).toBe(false);
     });
 
-    it("should return data with match set to false if appianSubmittedDate and SEA Tool submisison date don't match", async () => {
+    it("should send data to callback with match set to false if appianSubmittedDate and SEA Tool submisison date don't match", async () => {
       const mismatchedEvent = {
         Payload: {
           appianSubmittedDate: 1311638400000,

--- a/src/services/compare-appian/handlers/tests/compare.test.ts
+++ b/src/services/compare-appian/handlers/tests/compare.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, it, describe, expect, vi } from "vitest";
+import * as compare from "../compare";
+import * as libs from "../../../../libs";
+
+const appianCompare = compare as { handler: Function };
+
+const callback = vi.fn();
+
+const event = {
+  Payload: {
+    appianSubmittedDate: 1311638400000,
+    seatoolRecord: {
+      STATE_PLAN: {
+        ID_NUMBER: "NC-11-020",
+        SUBMISSION_DATE: 1311638400000,
+      },
+    },
+  },
+};
+
+describe("compare", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log");
+    vi.spyOn(libs, "trackError");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("with properly-formatted data", () => {
+    it("should not throw an error when passed properly-formatted data", async () => {
+      await appianCompare.handler(event, null, callback);
+      expect(libs.trackError).not.toHaveBeenCalled();
+    });
+
+    it("should return data with match set to true if Appian and SEA Tool submitted dates are the same", async () => {
+      await appianCompare.handler(event, null, callback);
+      expect(callback.mock.calls[0][1].hasOwnProperty("match")).toBe(true);
+      expect(callback.mock.calls[0][1]["match"]).toBe(true);
+    });
+
+    it("should log the received event in the expected format", async () => {
+      await appianCompare.handler(event, null, callback);
+
+      expect(console.log).toHaveBeenCalledWith(
+        "Received event:",
+        JSON.stringify(event, null, 2)
+      );
+    });
+  });
+
+  describe("with malformed or missing data", () => {
+    it("should throw an error when passed malformed data", async () => {
+      const malformedEvent = {
+        wrongData: {
+          malformed: "malformed data",
+        },
+      };
+
+      await appianCompare.handler(malformedEvent, null, callback);
+      expect(libs.trackError).toHaveBeenCalled();
+    });
+
+    it("should return data with match set to false if data doesn't include appianSubmittedDate", async () => {
+      const noAppianDate = {
+        Payload: {
+          seatoolRecord: {
+            STATE_PLAN: {
+              ID_NUMBER: "NC-11-020",
+              SUBMISSION_DATE: 1311638400000,
+            },
+          },
+        },
+      };
+
+      await appianCompare.handler(noAppianDate, null, callback);
+      expect(callback.mock.calls[0][1].hasOwnProperty("match")).toBe(true);
+      expect(callback.mock.calls[0][1]["match"]).toBe(false);
+    });
+
+    it("should return data with match set to false if appianSubmittedDate and SEA Tool submisison date don't match", async () => {
+      const mismatchedEvent = {
+        Payload: {
+          appianSubmittedDate: 1311638400000,
+          seatoolRecord: {
+            STATE_PLAN: {
+              ID_NUMBER: "NC-11-020",
+              SUBMISSION_DATE: 1111111100000,
+            },
+          },
+        },
+      };
+
+      await appianCompare.handler(mismatchedEvent, null, callback);
+      expect(callback.mock.calls[0][1].hasOwnProperty("match")).toBe(true);
+      expect(callback.mock.calls[0][1]["match"]).toBe(false);
+    });
+  });
+});

--- a/src/services/compare-appian/handlers/tests/getAppianData.test.ts
+++ b/src/services/compare-appian/handlers/tests/getAppianData.test.ts
@@ -1,0 +1,122 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  it,
+  describe,
+  expect,
+  vi,
+} from "vitest";
+import * as libs from "../../../../libs";
+import * as getAppianData from "../getAppianData";
+
+const handler = getAppianData as { handler: Function };
+const callback = vi.fn();
+
+const event = {
+  Payload: {
+    appianSubmittedDate: 1311638400000,
+    seatoolRecord: {
+      STATE_PLAN: {
+        ID_NUMBER: "NC-11-020",
+        SUBMISSION_DATE: 1311638400000,
+      },
+    },
+  },
+};
+
+const exampleAppianRecord = {
+  PK: "test-pk",
+  SK: "test-sk",
+  payload: {
+    SBMSSN_DATE: 1311638400000,
+    SPA_ID: "TEST-SPA-ID",
+  },
+};
+
+describe("getAppianData", () => {
+  describe("when process.env.appianTableName is not defined", () => {
+    it("should throw an error if process.env.appianTableName is not defined", async () => {
+      await expect(() =>
+        handler.handler(event, null, callback)
+      ).rejects.toThrowError(
+        "process.env.appianTableName needs to be defined."
+      );
+    });
+  });
+
+  describe("when process.env.appianTableName is defined", () => {
+    beforeEach(() => {
+      vi.spyOn(console, "log");
+      vi.spyOn(console, "error");
+      vi.spyOn(libs, "trackError");
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    beforeAll(() => {
+      process.env.appianTableName = "table-name";
+    });
+
+    describe("when an Appian record is found", () => {
+      beforeEach(() => {
+        vi.spyOn(libs, "getItem").mockImplementation(
+          async () => exampleAppianRecord
+        );
+      });
+
+      it("should not throw an error when passed properly-formatted data", async () => {
+        await handler.handler(event, null, callback);
+        expect(libs.getItem).toHaveBeenCalledOnce();
+        expect(libs.trackError).not.toHaveBeenCalled();
+      });
+
+      it("should log the received event in the expected format", async () => {
+        await handler.handler(event, null, callback);
+
+        expect(console.log).toHaveBeenCalledWith(
+          "Received event:",
+          JSON.stringify(event, null, 2)
+        );
+      });
+
+      it("should include appianRecord in the data sent to callback", async () => {
+        await handler.handler(event, null, callback);
+        expect(callback.mock.calls[0][1].hasOwnProperty("appianRecord")).toBe(
+          true
+        );
+        expect(callback.mock.calls[0][1]["appianRecord"]).toEqual(
+          exampleAppianRecord
+        );
+      });
+
+      it("should include SPA_ID in the data sent to the callback", async () => {
+        await handler.handler(event, null, callback);
+        expect(callback.mock.calls[0][1].hasOwnProperty("SPA_ID")).toBe(true);
+        expect(callback.mock.calls[0][1]["SPA_ID"]).toBe("TEST-SPA-ID");
+      });
+    });
+
+    describe("when no Appian record is found", () => {
+      beforeEach(() => {
+        vi.spyOn(libs, "getItem").mockImplementation(async () => null);
+      });
+
+      afterEach(() => {
+        vi.clearAllMocks();
+      });
+
+      it("should throw an error when no Appian record is found", async () => {
+        await handler.handler(event, null, callback);
+        expect(libs.getItem).toHaveBeenCalledOnce();
+        expect(libs.trackError).toHaveBeenCalled();
+        expect(console.error).toHaveBeenCalledWith(
+          "ERROR:",
+          JSON.stringify("No Appian record found", null, 2)
+        );
+      });
+    });
+  });
+});

--- a/src/services/compare-appian/handlers/tests/initStatus.test.ts
+++ b/src/services/compare-appian/handlers/tests/initStatus.test.ts
@@ -26,8 +26,12 @@ const event = {
 
 const callbackData = {
   iterations: 0,
-  PK: "PK-Test",
-  SK: "SK-Test",
+  PK: {
+    S: "PK-Test",
+  },
+  SK: {
+    S: "SK-Test",
+  },
 };
 
 describe("initStatus", () => {
@@ -49,7 +53,7 @@ describe("initStatus", () => {
 
     beforeEach(() => {
       vi.spyOn(console, "log").mockImplementation(() => {});
-      vi.spyOn(libs, "putItem").mockImplementation(() => {});
+      vi.spyOn(libs, "putItem");
       vi.spyOn(libs, "trackError");
     });
 

--- a/src/services/compare-appian/handlers/tests/initStatus.test.ts
+++ b/src/services/compare-appian/handlers/tests/initStatus.test.ts
@@ -1,0 +1,81 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import * as initStatus from "../initStatus";
+import * as libs from "../../../../libs";
+
+const handler = initStatus as { handler: Function };
+const callback = vi.fn();
+
+const event = {
+  Context: {
+    Execution: {
+      Input: {
+        PK: { S: "PK-Test" },
+        SK: { S: "SK-Test" },
+      },
+    },
+  },
+};
+
+const callbackData = {
+  iterations: 0,
+  PK: "PK-Test",
+  SK: "SK-Test",
+};
+
+describe("initStatus", () => {
+  describe("when process.env.statusTableName is not defined", () => {
+    it("throws an error if process.env.statusTableName is not defined", async () => {
+      await expect(() =>
+        handler.handler(event, null, callback)
+      ).rejects.toThrowError(
+        "process.env.statusTableName needs to be defined."
+      );
+    });
+  });
+
+  describe("when process.env.appianTableName is defined", () => {
+    beforeAll(() => {
+      process.env.statusTableName = "table-name";
+      process.env.region = "example-region";
+    });
+
+    beforeEach(() => {
+      vi.spyOn(console, "log").mockImplementation(() => {});
+      vi.spyOn(libs, "putItem").mockImplementation(() => {});
+      vi.spyOn(libs, "trackError");
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("logs the event", async () => {
+      await handler.handler(event, null, callback);
+      expect(console.log).toHaveBeenCalledWith(
+        "Received event:",
+        JSON.stringify(event, null, 2)
+      );
+    });
+
+    it("calls putItem as expected", async () => {
+      await handler.handler(event, null, callback);
+      expect(libs.putItem).toBeCalledWith({
+        tableName: "table-name",
+        item: callbackData,
+      });
+    });
+
+    it("passes data to the callback", async () => {
+      await handler.handler(event, null, callback);
+      expect(callback.mock.calls[0][1]).toMatchObject(callbackData);
+    });
+  });
+});

--- a/src/services/compare-appian/handlers/tests/seatoolRecordExist.test.ts
+++ b/src/services/compare-appian/handlers/tests/seatoolRecordExist.test.ts
@@ -1,0 +1,107 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import * as seatoolRecordExists from "../seatoolRecordExist";
+import * as libs from "../../../../libs";
+
+const handler = seatoolRecordExists as { handler: Function };
+const callback = vi.fn();
+
+const event = { Payload: {} };
+
+const mockSubmittedDate = 1311638400000;
+const mockSpaId = "test-spa-id";
+const exampleAppianRecord = {
+  PK: "test-pk",
+  SK: "test-sk",
+  Payload: {
+    SBMSSN_DATE: mockSubmittedDate,
+    SPA_ID: mockSpaId,
+  },
+};
+
+describe("seatoolRecordExists", () => {
+  describe("when process.env.statusTableName is not defined", () => {
+    it("throws an error if process.env.statusTableName is not defined", async () => {
+      await expect(() =>
+        handler.handler(event, null, callback)
+      ).rejects.toThrowError(
+        "process.env.seatoolTableName needs to be defined."
+      );
+    });
+  });
+
+  describe("when process.env.statusTableName is defined", () => {
+    beforeAll(() => {
+      process.env.seatoolTableName = "table-name";
+    });
+
+    beforeEach(() => {
+      vi.spyOn(console, "log");
+      vi.spyOn(libs, "getItem");
+      vi.spyOn(libs, "trackError");
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    describe("when a matching SEA Tool record is found", () => {
+      beforeEach(() => {
+        vi.spyOn(libs, "getItem").mockImplementation(
+          async () => exampleAppianRecord
+        );
+      });
+
+      it("does not throw an error when passed properly-formatted data", async () => {
+        await handler.handler(event, null, callback);
+        expect(libs.trackError).not.toHaveBeenCalled();
+      });
+
+      it("logs the received event in the expected format", async () => {
+        await handler.handler(event, null, callback);
+        expect(console.log).toHaveBeenCalledWith(
+          "Received event:",
+          JSON.stringify(event, null, 2)
+        );
+      });
+
+      it("calls getItem as expected", async () => {
+        await handler.handler(event, null, callback);
+        expect(libs.getItem).toHaveBeenCalledOnce();
+      });
+
+      it("sets seatoolExist to true", async () => {
+        await handler.handler(event, null, callback);
+        console.info("callback", callback.mock.calls[0][1]);
+        expect(callback.mock.calls[0][1]["seatoolExist"]).toBe(true);
+      });
+
+      it("sets the seatoolRecord as expected", async () => {
+        await handler.handler(event, null, callback);
+        expect(callback.mock.calls[0][1]["seatoolRecord"]).toMatchObject(
+          exampleAppianRecord
+        );
+      });
+    });
+
+    describe("when no matching SEA Tool record is found", () => {
+      beforeEach(() => {
+        vi.spyOn(libs, "getItem").mockImplementation(async () => null);
+      });
+
+      it("logs an error", async () => {
+        await handler.handler(event, null, callback);
+        expect(console.log).toBeCalledWith(
+          `No Seatool record found for Appian record: undefined`
+        );
+      });
+    });
+  });
+});

--- a/src/services/compare-appian/handlers/tests/sendNoMatchAlert.test.ts
+++ b/src/services/compare-appian/handlers/tests/sendNoMatchAlert.test.ts
@@ -1,0 +1,51 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import * as sendNoMatchAlert from "../sendNoMatchAlert";
+import { doesSecretExist } from "../../../../libs";
+
+vi.mock("../../../../libs");
+
+const handler = sendNoMatchAlert as { handler: Function };
+const callback = vi.fn();
+const event = { Payload: {} };
+
+describe("sendNoMatchAlert", () => {
+  describe.skip("when process.env values are not set", async () => {
+    it("throws an error if process.env.region is not defined", async () => {
+      await expect(() =>
+        handler.handler(event, null, callback)
+      ).rejects.toThrowError("process.env.region needs to be defined.");
+    });
+  });
+
+  describe("when process.env values are set", async () => {
+    beforeAll(() => {
+      process.env.project = "test-project";
+      process.env.region = "test-region";
+      process.env.stage = "test-state";
+    });
+
+    beforeEach(() => {
+      vi.spyOn(console, "log");
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("logs the received event", async () => {
+      await handler.handler(event, null, callback);
+      expect(console.log).toHaveBeenCalledWith(
+        "Received event:",
+        JSON.stringify(event, null, 2)
+      );
+    });
+  });
+});

--- a/src/services/compare-appian/handlers/tests/sendNoMatchAlert.test.ts
+++ b/src/services/compare-appian/handlers/tests/sendNoMatchAlert.test.ts
@@ -17,7 +17,7 @@ const callback = vi.fn();
 const event = { Payload: {} };
 
 describe("sendNoMatchAlert", () => {
-  describe.skip("when process.env values are not set", async () => {
+  describe("when process.env values are not set", async () => {
     it("throws an error if process.env.region is not defined", async () => {
       await expect(() =>
         handler.handler(event, null, callback)

--- a/src/services/compare-appian/handlers/tests/sendReport.test.ts
+++ b/src/services/compare-appian/handlers/tests/sendReport.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as sendReport from "../sendReport";
+import * as libs from "../../../../libs";
+
+vi.mock("../../../../libs", () => {
+  return {
+    scanTable: vi.fn().mockImplementation(() => appianReportData),
+    trackError: vi.fn(),
+  };
+});
+
+const appianReportData = [
+  {
+    PK: "test-pk",
+    SK: "test-sk",
+    isAppianSubmitted: true,
+    SPA_ID: "test-id",
+    iterations: 0,
+    secSinceAppianSubmitted: 123,
+    appianSubmittedDate: 1234567890,
+    seatoolExist: true,
+    seatoolSubmissionDate: 1234567890, // optional
+    match: true, // optional
+  },
+];
+
+const handler = sendReport as { handler: Function };
+
+describe("sendReport", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should log the received event in the expected format", async () => {
+    process.env.statusTable = "test-table";
+    vi.spyOn(console, "log");
+    const event = { recipient: "recipient@example.com" };
+    await handler.handler(event);
+
+    expect(console.log).toHaveBeenCalledWith(
+      "Received event:",
+      JSON.stringify(event, null, 2)
+    );
+  });
+
+  it("throws an error if no email provided", async () => {
+    const event = { recipient: null };
+    await expect(() =>
+      handler
+        .handler(event)
+        .rejects.toThrowError(
+          'You must manually provide a recipient email in the event to send a report. ex. {"recipient": "user@example.com"}'
+        )
+    );
+  });
+
+  it("throws an error if process.env.statusTable is not set", async () => {
+    await expect(() =>
+      handler
+        .handler(event)
+        .rejects.toThrowError("process.env.statusTable needs to be defined.")
+    );
+  });
+
+  it("gets data from scanTable", async () => {
+    const event = { recipient: "recipient@example.com" };
+    process.env.statusTable = "test-table";
+
+    await handler.handler(event);
+    expect(libs.scanTable).toHaveBeenCalledOnce();
+    expect(libs.trackError).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/compare-appian/handlers/tests/stopExecutions.test.ts
+++ b/src/services/compare-appian/handlers/tests/stopExecutions.test.ts
@@ -32,7 +32,7 @@ describe("stopExecutions", () => {
     vi.clearAllMocks();
   });
 
-  it("logs the received event in the expected format", async () => {
+  it("logs the request in the expected format", async () => {
     await handler.handler(event);
     expect(console.log).toHaveBeenCalledWith(
       "Request:",

--- a/src/services/compare-appian/handlers/tests/stopExecutions.test.ts
+++ b/src/services/compare-appian/handlers/tests/stopExecutions.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CloudFormationCustomResourceEvent } from "aws-lambda";
+import * as stopExecutions from "../stopExecutions";
+import * as cfn from "cfn-response-async";
+
+vi.mock("cfn-response-async");
+
+const handler = stopExecutions as { handler: Function };
+
+// const sfnClientMock = mockClient(SFNClient);
+
+const event: CloudFormationCustomResourceEvent = {
+  ServiceToken: "test-token",
+  ResponseURL: "responseUrl",
+  StackId: "1234",
+  RequestId: "1234",
+  LogicalResourceId: "1234",
+  ResourceType: "test-resource",
+  ResourceProperties: {
+    ServiceToken: "1234",
+  },
+  RequestType: "Create",
+};
+
+describe("stopExecutions", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log");
+    vi.spyOn(cfn, "send");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("logs the received event in the expected format", async () => {
+    await handler.handler(event);
+    expect(console.log).toHaveBeenCalledWith(
+      "Request:",
+      JSON.stringify(event, null, 2)
+    );
+  });
+
+  it("logs a Create event", async () => {
+    const createEvent = { RequestType: "Create" };
+
+    await handler.handler(createEvent);
+    expect(console.log).toHaveBeenCalledWith("create", createEvent);
+    expect(console.log).toHaveBeenCalledWith(
+      "This function does nothing on Create events"
+    );
+  });
+
+  it("logs an Update event", async () => {
+    const updateEvent = { RequestType: "Update" };
+
+    await handler.handler(updateEvent);
+    expect(console.log).toHaveBeenCalledWith("update", updateEvent);
+    expect(console.log).toHaveBeenCalledWith(
+      "This function does nothing on Update events"
+    );
+  });
+
+  it("logs a Delete event", async () => {
+    const deleteEvent = { RequestType: "Delete" };
+    await handler.handler(deleteEvent);
+    expect(console.log).toHaveBeenCalledWith("delete", deleteEvent);
+  });
+
+  it("sends the event", async () => {
+    const deleteEvent = { RequestType: "Delete" };
+    await handler.handler(deleteEvent);
+    expect(cfn.send).toHaveBeenCalledOnce();
+  });
+});

--- a/src/services/compare-appian/handlers/tests/updateStatus.test.ts
+++ b/src/services/compare-appian/handlers/tests/updateStatus.test.ts
@@ -1,0 +1,83 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import * as updateStatus from "../updateStatus";
+import * as libs from "../../../../libs";
+
+vi.mock("../../../../libs", () => {
+  return {
+    putItem: vi.fn(),
+    trackError: vi.fn(),
+  };
+});
+
+const handler = updateStatus as { handler: Function };
+const callback = vi.fn();
+const event = { Payload: { iterations: 0 } };
+
+describe("updateStatus", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("without process.env.statusTableName defined", () => {
+    it("throws an error", async () => {
+      await expect(() =>
+        handler.handler(event, null, callback)
+      ).rejects.toThrowError(
+        "process.env.statusTableName needs to be defined."
+      );
+    });
+  });
+
+  describe("with process.env.statusTableName", () => {
+    beforeAll(() => {
+      process.env.statusTableName = "table-name";
+    });
+
+    it("does not throw an error", async () => {
+      await expect(() =>
+        handler.handler(event, null, callback)
+      ).not.toThrowError("process.env.statusTableName needs to be defined.");
+    });
+
+    it("logs the received event in the expected format", async () => {
+      await handler.handler(event, null, callback);
+      expect(console.log).toHaveBeenCalledWith(
+        "Received event:",
+        JSON.stringify(event, null, 2)
+      );
+    });
+
+    it("calls putItem with the expected parameters", async () => {
+      await handler.handler(event, null, callback);
+      expect(libs.putItem).toHaveBeenCalledWith({
+        tableName: "table-name",
+        item: {
+          iterations: 1,
+        },
+      });
+    });
+
+    it("logs the data after update", async () => {
+      const data = {
+        iterations: 1,
+      };
+
+      await handler.handler(event, null, callback);
+      expect(console.log).toHaveBeenCalledWith(
+        `data after updating item: ${JSON.stringify(data, null, 2)}`
+      );
+    });
+  });
+});

--- a/src/services/compare-appian/handlers/tests/workflowStarter.test.ts
+++ b/src/services/compare-appian/handlers/tests/workflowStarter.test.ts
@@ -1,0 +1,157 @@
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import * as workflowStarter from "../workflowStarter";
+import * as libs from "../../../../libs";
+
+const handler = workflowStarter as { handler: Function };
+
+const testPK = "test-pk";
+const testSK = "test-sk";
+
+const event = {
+  Records: [{ dynamodb: { Keys: { PK: { S: testPK }, SK: { S: testSK } } } }],
+};
+
+const oldAppianRecord = {
+  PK: testPK,
+  SK: testSK,
+  payload: {
+    SBMSSN_DATE: 1311638400000,
+    SBMSSN_TYPE: "oFfIcIaL", // this should be case insensitive
+    SPA_ID: "TEST-SPA-ID",
+  },
+};
+
+// 10 days ago
+let recentDate = new Date();
+recentDate.setDate(recentDate.getDate() - 10);
+
+const recentAppianRecord = {
+  PK: testPK,
+  SK: testSK,
+  payload: {
+    SBMSSN_DATE: 1311638400000,
+    SBMSSN_TYPE: "oFfIcIaL", // this should be case insensitive
+    SPA_ID: "TEST-SPA-ID",
+  },
+};
+
+describe("workflowStarter", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "log");
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("throws an error if process.env.appianTableName is not set", async () => {
+    await expect(handler.handler(event)).rejects.toThrowError(
+      /^process.env.appianTableName needs to be defined.$/
+    );
+  });
+
+  describe("with process.env.appianTableName set", () => {
+    beforeAll(() => {
+      process.env.appianTableName = "test-table-name";
+      // process.env.region = "test-region";
+    });
+
+    it("logs the received event as expected", async () => {
+      await handler.handler(event);
+      expect(console.log).toHaveBeenCalledWith(
+        "Received event:",
+        JSON.stringify(event, null, 2)
+      );
+    });
+
+    // process.env.workflowStatus = "OFF"
+    describe("with process.env.workflowsStatus set to OFF", () => {
+      beforeAll(() => {
+        process.env.workflowsStatus = "OFF";
+      });
+
+      it("prints a log when workflows status is not set to ON", async () => {
+        await handler.handler(event);
+        expect(console.log).toHaveBeenCalledWith(
+          'Workflows status is currently not "ON". not starting workflow'
+        );
+      });
+    });
+
+    // process.env.workflowStatus = "ON"
+    describe("with process.env.workflowsStatus set to ON", () => {
+      beforeAll(() => {
+        process.env.workflowsStatus = "ON";
+      });
+
+      // No Appian record
+      describe("with no Appian record found", () => {
+        beforeEach(() => {
+          vi.spyOn(libs, "getItem").mockImplementation(async () => null);
+        });
+
+        it("throws an error when no Appian record is found", async () => {
+          await expect(handler.handler(event)).rejects.toThrowError(
+            "No appian record found"
+          );
+        });
+      });
+
+      // Valid appian record
+      describe("with an old Appian record found", () => {
+        beforeEach(() => {
+          vi.spyOn(libs, "getItem").mockImplementation(
+            async () => oldAppianRecord
+          );
+        });
+
+        it("calls getItem as expected", async () => {
+          await handler.handler(event);
+          expect(libs.getItem).toHaveBeenCalledWith({
+            tableName: "test-table-name",
+            key: { PK: testPK, SK: testSK },
+          });
+        });
+
+        it("does not throw an error when an Appian record is found", async () => {
+          await expect(handler.handler(event)).resolves.not.toThrowError();
+        });
+
+        it("logs a message if the record is > 200 days old", async () => {
+          await handler.handler(event);
+          expect(console.log).toHaveBeenCalledWith(
+            `Record ${testPK} not submitted within last 200 days. Ignoring...`
+          );
+        });
+      });
+
+      describe("with an Appian record < 200 days old", async () => {
+        beforeEach(() => {
+          vi.spyOn(libs, "getItem").mockImplementation(
+            async () => recentAppianRecord
+          );
+        });
+
+        it("calls getItem as expected", async () => {
+          await handler.handler(event);
+          expect(libs.getItem).toHaveBeenCalledWith({
+            tableName: "test-table-name",
+            key: { PK: testPK, SK: testSK },
+          });
+        });
+
+        it("does not throw an error when an Appian record is found", async () => {
+          await expect(handler.handler(event)).resolves.not.toThrowError();
+        });
+      });
+    });
+  });
+});

--- a/src/tests/vitest.config.ts
+++ b/src/tests/vitest.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  test: {},
+  test: {
+    // We have to set interopDefault to true in order to import lodash into our
+    // tests. Vitest requires libraries to export ES modules, which lodash
+    // does not. For more, see:
+    // https://github.com/vitest-dev/vitest/issues/2544#issuecomment-1361055399
+    deps: { interopDefault: true },
+    silent: false,
+  },
 });


### PR DESCRIPTION
## Purpose

Adds unit tests for the `compare-appian` handlers.

#### Linked Issues to Close

[OY2-23129](https://qmacbis.atlassian.net/browse/OY2-23129)

## Approach

_How does this change address the issue?_

## Assorted Notes/Considerations/Learning

_List any other information that you think is important... a post-merge activity, someone to notify, what you learned, etc._
